### PR TITLE
Enable browser native spell checker by default, D6LTS backport

### DIFF
--- a/ckeditor.config.js
+++ b/ckeditor.config.js
@@ -86,7 +86,7 @@ Drupal.settings.cke_toolbar_DrupalAdvanced = [
     ['DrupalBreak', 'DrupalPageBreak']
 ];
 
-// Toolbar definiton for all buttons
+// Toolbar definition for all buttons
 Drupal.settings.cke_toolbar_DrupalFull = [
     ['Source'],
     ['Cut','Copy','Paste','PasteText','PasteFromWord','-','SpellChecker', 'Scayt'],
@@ -103,3 +103,21 @@ Drupal.settings.cke_toolbar_DrupalFull = [
     ['Maximize', 'ShowBlocks'],
     ['DrupalBreak', 'DrupalPageBreak']
 ];
+
+/**
+ * To enable browser native spell checker uncomment (default) first of following two lines.
+ * The second line (is a default setting and can leave commented) allows access
+ * to browser context menu with ctrl-right-click otherwise there is no access to
+ * the browser context menu without further config changes
+ */
+CKEDITOR.config.disableNativeSpellChecker = false;
+// CKEDITOR.config.browserContextMenuOnCtrl = true;
+
+/** NOT TESTED
+ * For browser default context menu on right-click rather than ctrl-right-click
+ * Note: Disabling Ckeditor's context menu may render it impossible to work with tables
+ * uncomment following lines;
+ * three plugins need to be removed because scayt depends on menubutton which depends on contextmenu
+ */
+// config.browserContextMenuOnCtrl = false;
+// config.removePlugins = 'scayt,menubutton,contextmenu';

--- a/includes/ckeditor.page.inc
+++ b/includes/ckeditor.page.inc
@@ -140,6 +140,9 @@ function ckeditor_help_delegate($path, $arg) {
       ) .
       '</li>' .
       '<li>' .
+      t('By default, CKEditor is configured to leverage your browser\'s spell check capability. Make sure your browser\'s spell checker is enabled in your browser\'s settings. To access suggested corrections for misspelled words, it may be necessary to hold the <em>Control</em> or <em>command</em> (Mac) key while right-clicking the misspelling.') .
+      '</li>' .
+      '<li>' .         
       t('All configuration options described in the !apidocs that cannot be easily changed in the administration area can be set in the <strong>Advanced Options</strong> section in the CKEditor profile.',
         array(
           '!apidocs' => l(t('API documentation'), 'http://docs.cksource.com/ckeditor_api/symbols/CKEDITOR.config.html')


### PR DESCRIPTION
This is a PR of the patch in https://www.drupal.org/project/d6lts/issues/3254053 as a D6LTS backport of similar changes applied to D7 and D8 versions of the CKEditor module.

Also, as a separate issue, https://www.drupal.org/project/d6lts/issues/3254052, the latest version ckeditor-6.x-1.18 does not show on the Available updates report or with "drush --release-backend=mydropwizard rl ckeditor". This problem is similar to the problem encountered with the update_advanced module that was recently fixed.